### PR TITLE
Fix placement of invalid-text within a horizontal radio group

### DIFF
--- a/packages/core/src/components/field-group/field-group.scss
+++ b/packages/core/src/components/field-group/field-group.scss
@@ -24,13 +24,16 @@
   margin: 0;
   padding: 0;
   border: none;
+}
+
+.content {
   display: flex;
   flex-direction: column;
   align-items: var(--align-fields);
   gap: var(--margin-between-fields);
 }
 
-.field-group.field-group-horizontal {
+.field-group-horizontal .content {
   flex-direction: row;
   gap: var(--margin-between-fields-horizontal);
 }

--- a/packages/core/src/components/field-group/field-group.tsx
+++ b/packages/core/src/components/field-group/field-group.tsx
@@ -58,7 +58,9 @@ export class FieldGroup {
         <legend class="field-group-label" aria-hidden={hasLabel ? 'false' : 'true'}>
           <slot name="label">{this.label}</slot>
         </legend>
-        <slot></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
       </fieldset>
     );
   }

--- a/packages/core/src/components/radio-group/radio-group.scss
+++ b/packages/core/src/components/radio-group/radio-group.scss
@@ -24,13 +24,16 @@
   margin: 0;
   padding: 0;
   border: none;
+}
+
+.content {
   display: flex;
   flex-direction: column;
   align-items: var(--align-radios);
   gap: var(--margin-between-radios);
 }
 
-.radio-group.radio-group-horizontal {
+.radio-group-horizontal .content {
   flex-direction: row;
   gap: var(--margin-between-radios-horizontal);
 }

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -214,7 +214,9 @@ export class RadioGroup {
               </span>
             )}
           </legend>
-          <slot></slot>
+          <div class="content">
+            <slot></slot>
+          </div>
           {showInvalidText && (
             <div
               id={this.invalidTextId}

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -21,6 +21,110 @@
   </head>
   <body>
     <section>
+      <h2>gr-radio & gr-radio-group</h2>
+
+      <section>
+        <h3>Default (vertical)</h3>
+
+        <gr-radio-group label="Select an option" value="3">
+          <gr-radio value="1">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+        </gr-radio-group>
+      </section>
+
+      <section>
+        <h3>Horizontal</h3>
+
+        <gr-radio-group label="Select an option" value="3" horizontal>
+          <gr-radio value="1">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+        </gr-radio-group>
+      </section>
+
+      <section>
+        <h3>Disabled option</h3>
+
+        <gr-radio-group label="Select an option" value="2">
+          <gr-radio value="1">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+          <gr-radio value="4" disabled>Disabled</gr-radio>
+        </gr-radio-group>
+      </section>
+
+      <section>
+        <h3>Invalid</h3>
+
+        <gr-radio-group label="Select an option" invalid-text="Select an option" invalid>
+          <gr-radio value="1">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+        </gr-radio-group>
+      </section>
+
+      <section>
+        <h3>Invalid with horizontal</h3>
+
+        <gr-radio-group label="Select an option" invalid-text="Select an option" horizontal invalid>
+          <gr-radio value="1">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+        </gr-radio-group>
+      </section>
+
+      <section>
+        <h3>Required indicator</h3>
+
+        <gr-radio-group label="Select an option" required-indicator>
+          <gr-radio value="1" aria-label="Option one">Option 1</gr-radio>
+          <gr-radio value="2">Option 2</gr-radio>
+          <gr-radio value="3">Option 3</gr-radio>
+        </gr-radio-group>
+      </section>
+    </section>
+
+    <section>
+      <h2>gr-checkbox & gr-field-group</h2>
+
+      <section style="width: 300px">
+        <h3>Checked</h3>
+        <gr-field-group label="Select options">
+          <gr-checkbox id="checkbox-test" checked invalid aria-label="Option one">Option 1</gr-checkbox>
+          <gr-checkbox invalid>Option 2</gr-checkbox>
+          <gr-checkbox invalid-text="Select at least one option" invalid>Option 3</gr-checkbox>
+        </gr-field-group>
+      </section>
+
+      <section>
+        <h3>Horizontal</h3>
+        <gr-field-group label="Select options" horizontal>
+          <gr-checkbox>Option 1</gr-checkbox>
+          <gr-checkbox>Option 2</gr-checkbox>
+          <gr-checkbox>Option 3</gr-checkbox>
+        </gr-field-group>
+      </section>
+
+      <section>
+        <h3>Indeterminate</h3>
+        <gr-checkbox indeterminate>Indeterminate</gr-checkbox>
+      </section>
+
+      <section>
+        <h3>Disabled</h3>
+        <gr-checkbox disabled>Disabled</gr-checkbox>
+      </section>
+
+      <section>
+        <h3>Invalid</h3>
+        <gr-checkbox invalid-text="You have to agree with our terms to continue" invalid>
+          I agree with the terms
+        </gr-checkbox>
+      </section>
+    </section>
+
+    <section>
       <h2>gr-date-picker</h2>
 
       <section>
@@ -488,100 +592,6 @@
         <h3>Expand with Content</h3>
 
         <gr-textarea resize="auto"></gr-textarea>
-      </section>
-    </section>
-
-    <section>
-      <h2>gr-radio & gr-radio-group</h2>
-
-      <section>
-        <h3>Default (vertical)</h3>
-
-        <gr-radio-group label="Select an option" value="3">
-          <gr-radio value="1">Option 1</gr-radio>
-          <gr-radio value="2">Option 2</gr-radio>
-          <gr-radio value="3">Option 3</gr-radio>
-        </gr-radio-group>
-      </section>
-
-      <section>
-        <h3>Horizontal</h3>
-
-        <gr-radio-group label="Select an option" value="3" horizontal>
-          <gr-radio value="1">Option 1</gr-radio>
-          <gr-radio value="2">Option 2</gr-radio>
-          <gr-radio value="3">Option 3</gr-radio>
-        </gr-radio-group>
-      </section>
-
-      <section>
-        <h3>Disabled option</h3>
-
-        <gr-radio-group label="Select an option" value="2">
-          <gr-radio value="1">Option 1</gr-radio>
-          <gr-radio value="2">Option 2</gr-radio>
-          <gr-radio value="3">Option 3</gr-radio>
-          <gr-radio value="4" disabled>Disabled</gr-radio>
-        </gr-radio-group>
-      </section>
-
-      <section>
-        <h3>Invalid</h3>
-
-        <gr-radio-group label="Select an option" invalid-text="Select an option" invalid>
-          <gr-radio value="1">Option 1</gr-radio>
-          <gr-radio value="2">Option 2</gr-radio>
-          <gr-radio value="3">Option 3</gr-radio>
-        </gr-radio-group>
-      </section>
-
-      <section>
-        <h3>Required indicator</h3>
-
-        <gr-radio-group label="Select an option" required-indicator>
-          <gr-radio value="1" aria-label="Option one">Option 1</gr-radio>
-          <gr-radio value="2">Option 2</gr-radio>
-          <gr-radio value="3">Option 3</gr-radio>
-        </gr-radio-group>
-      </section>
-    </section>
-
-    <section>
-      <h2>gr-checkbox & gr-field-group</h2>
-
-      <section style="width: 300px">
-        <h3>Checked</h3>
-        <gr-field-group label="Select options">
-          <gr-checkbox id="checkbox-test" checked invalid aria-label="Option one">Option 1</gr-checkbox>
-          <gr-checkbox invalid>Option 2</gr-checkbox>
-          <gr-checkbox invalid-text="Select at least one option" invalid>Option 3</gr-checkbox>
-        </gr-field-group>
-      </section>
-
-      <section>
-        <h3>Horizontal</h3>
-        <gr-field-group label="Select options" horizontal>
-          <gr-checkbox>Option 1</gr-checkbox>
-          <gr-checkbox>Option 2</gr-checkbox>
-          <gr-checkbox>Option 3</gr-checkbox>
-        </gr-field-group>
-      </section>
-
-      <section>
-        <h3>Indeterminate</h3>
-        <gr-checkbox indeterminate>Indeterminate</gr-checkbox>
-      </section>
-
-      <section>
-        <h3>Disabled</h3>
-        <gr-checkbox disabled>Disabled</gr-checkbox>
-      </section>
-
-      <section>
-        <h3>Invalid</h3>
-        <gr-checkbox invalid-text="You have to agree with our terms to continue" invalid>
-          I agree with the terms
-        </gr-checkbox>
       </section>
     </section>
 


### PR DESCRIPTION
Was being shown to the right of the radios, instead of underneath them. This fixes this. For consistency I have applied the same css structure changes to the field-group.