### PR TITLE
hide dropdown popover if dropdown is marked as closed

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -593,6 +593,9 @@ export namespace Components {
           * The tag's size.
          */
         "size": 'small' | 'medium' | 'large';
+        /**
+          * The tag's title.
+         */
         "title": string;
         /**
           * Set to true to make the tag truncated.
@@ -1502,6 +1505,9 @@ declare namespace LocalJSX {
           * The tag's size.
          */
         "size"?: 'small' | 'medium' | 'large';
+        /**
+          * The tag's title.
+         */
         "title"?: string;
         /**
           * Set to true to make the tag truncated.

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -84,3 +84,6 @@
     pointer-events: all;
   }
 }
+.dropdown-closed .dropdown-positioner {
+  display: none;
+}

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -359,6 +359,7 @@ export class Dropdown {
         id={this.componentId}
         class={{
           'dropdown-open': this.open,
+          'dropdown-closed': !this.open,
         }}
       >
         <span


### PR DESCRIPTION
I found I had still this diff around related to a small issue I found in the gr-dropdown

it seems the dropdown popover section is not completely hidden when the dropdown is closed. I think it's a race condition between updating the options/selected value and having the popover open. The result is that you can not click below the dropdown, because the popover div hovers over the site contents with visibility: hidden. It can be fixed easily by forcing the popover to be hidden.